### PR TITLE
window.closed fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20246,6 +20246,7 @@
         "@toruslabs/metadata-helpers": "^4.0.0",
         "@toruslabs/openlogin-session-manager": "^1.1.0",
         "@toruslabs/openlogin-utils": "^4.7.0",
+        "bowser": "^2.11.0",
         "events": "^3.3.0",
         "loglevel": "^1.8.1",
         "ts-custom-error": "^3.3.1"

--- a/packages/openlogin/package.json
+++ b/packages/openlogin/package.json
@@ -20,6 +20,7 @@
     "pre-commit": "lint-staged --cwd ."
   },
   "dependencies": {
+    "bowser": "^2.11.0",
     "@toruslabs/broadcast-channel": "^7.0.0",
     "@toruslabs/eccrypto": "^3.0.0",
     "@toruslabs/metadata-helpers": "^4.0.0",

--- a/packages/openlogin/src/OpenLogin.ts
+++ b/packages/openlogin/src/OpenLogin.ts
@@ -17,7 +17,7 @@ import log from "loglevel";
 
 import { InitializationError, LoginError } from "./errors";
 import PopupHandler from "./PopupHandler";
-import { constructURL, getHashQueryParams, version } from "./utils";
+import { constructURL, getHashQueryParams, getTimeout, version } from "./utils";
 
 class OpenLogin {
   state: OpenloginSessionData = {};
@@ -176,7 +176,7 @@ class OpenLogin {
         baseURL: base64url,
         hash: { b64Params: jsonToBase64(configParams) },
       });
-      const currentWindow = new PopupHandler({ url: loginUrl });
+      const currentWindow = new PopupHandler({ url: loginUrl, timeout: getTimeout(params.loginProvider) });
 
       currentWindow.on("close", () => {
         reject(LoginError.popupClosed());

--- a/packages/openlogin/src/PopupHandler.ts
+++ b/packages/openlogin/src/PopupHandler.ts
@@ -16,7 +16,9 @@ class PopupHandler extends EventEmitter {
 
   iClosedWindow: boolean;
 
-  constructor({ url, target, features }: { url: string; target?: string; features?: string }) {
+  timeout: number;
+
+  constructor({ url, target, features, timeout = 30000 }: { url: string; target?: string; features?: string; timeout?: number }) {
     super();
     this.url = url;
     this.target = target || "_blank";
@@ -24,6 +26,7 @@ class PopupHandler extends EventEmitter {
     this.window = undefined;
     this.windowTimer = undefined;
     this.iClosedWindow = false;
+    this.timeout = timeout;
     this._setupTimer();
   }
 
@@ -32,11 +35,13 @@ class PopupHandler extends EventEmitter {
       setInterval(() => {
         if (this.window && this.window.closed) {
           clearInterval(this.windowTimer);
-          if (!this.iClosedWindow) {
-            this.emit("close");
-          }
-          this.iClosedWindow = false;
-          this.window = undefined;
+          setTimeout(() => {
+            if (!this.iClosedWindow) {
+              this.emit("close");
+            }
+            this.iClosedWindow = false;
+            this.window = undefined;
+          }, this.timeout);
         }
         if (this.window === undefined) clearInterval(this.windowTimer);
       }, 500)

--- a/packages/openlogin/src/utils.ts
+++ b/packages/openlogin/src/utils.ts
@@ -1,6 +1,7 @@
 import { getPublic, sign } from "@toruslabs/eccrypto";
 import { keccak256 } from "@toruslabs/metadata-helpers";
-import { base64url, safeatob } from "@toruslabs/openlogin-utils";
+import { base64url, LOGIN_PROVIDER, safeatob } from "@toruslabs/openlogin-utils";
+import bowser from "bowser";
 
 import log from "./loglevel";
 
@@ -105,4 +106,17 @@ export function getPopupFeatures(): string {
   const top = Math.abs((height - h) / 2 / systemZoom + dualScreenTop);
   const features = `titlebar=0,toolbar=0,status=0,location=0,menubar=0,height=${h / systemZoom},width=${w / systemZoom},top=${top},left=${left}`;
   return features;
+}
+
+export function isMobileOrTablet(): boolean {
+  const browser = bowser.getParser(window.navigator.userAgent);
+  const platform = browser.getPlatform();
+  return platform.type === bowser.PLATFORMS_MAP.tablet || platform.type === bowser.PLATFORMS_MAP.mobile;
+}
+
+export function getTimeout(loginProvider: string) {
+  if ((loginProvider === LOGIN_PROVIDER.FACEBOOK || loginProvider === LOGIN_PROVIDER.LINE) && isMobileOrTablet()) {
+    return 1000 * 60 * 5; // 5 minutes to finish the login
+  }
+  return 1000 * 10; // 10 seconds
 }


### PR DESCRIPTION
optimistically wait for fb and line logins to finish in mobile browsers because window.closed isn't reliable in browsers with cross-origin-opener-policy set