### PR TITLE
Fix storage instance caching

### DIFF
--- a/packages/openlogin-utils/src/browserStorage.ts
+++ b/packages/openlogin-utils/src/browserStorage.ts
@@ -14,7 +14,7 @@ export class MemoryStore implements IStorage {
 
 export class BrowserStorage {
   // eslint-disable-next-line no-use-before-define
-  private static instance: BrowserStorage;
+  private static instanceCache: Record<string, BrowserStorage> = {};
 
   public storage: IStorage;
 
@@ -33,7 +33,8 @@ export class BrowserStorage {
   }
 
   static getInstance(key: string, storageKey: "session" | "local" = "local"): BrowserStorage {
-    if (!this.instance) {
+    const instanceCacheKey = `${storageKey}_${key}`;
+    if (!this.instanceCache[instanceCacheKey]) {
       let storage: IStorage;
       if (storageKey === "local" && storageAvailable("localStorage")) {
         storage = window.localStorage;
@@ -43,9 +44,9 @@ export class BrowserStorage {
         storage = new MemoryStore();
       }
 
-      this.instance = new this(key, storage);
+      this.instanceCache[instanceCacheKey] = new this(key, storage);
     }
-    return this.instance;
+    return this.instanceCache[instanceCacheKey];
   }
 
   toJSON(): string {

--- a/packages/openlogin-utils/src/browserStorage.ts
+++ b/packages/openlogin-utils/src/browserStorage.ts
@@ -32,7 +32,7 @@ export class BrowserStorage {
     }
   }
 
-  static getInstance(key: string, storageKey: "session" | "local" = "local"): BrowserStorage {
+  static getInstance(key: string, storageKey: "session" | "local" | "memory" = "local"): BrowserStorage {
     const instanceCacheKey = `${storageKey}_${key}`;
     if (!this.instanceCache[instanceCacheKey]) {
       let storage: IStorage;


### PR DESCRIPTION
We noticed that when we tried to work with two different instances of web3auth libs, both of them trying to restore its own session, and hence depending on a different storage key, they both were writing to the same storage key despite passing different parameters to the underlying `BrowserStorage`.

We found the root cause to be the static instance caching in the class which kept returning the same instance despite the parameters passed and this PR provides a fix for that.

Another minor issue we noticed is that the type of storage `memory` can't be requested without TS "complaining" so this is fixed in the second commit

Once this is merged/released, to properly fix the issue the libs depending on this lib (`@web3auth/single-factor-auth`, etc.) need to be updated so they stop "competing" for the same instance of the `BrowserStorage` instance despite potentially wanting it with different params