### PR TITLE
feat: overwrite error.stack when ReactNative flag is set

### DIFF
--- a/packages/openlogin-jrpc/src/jrpcEngine.ts
+++ b/packages/openlogin-jrpc/src/jrpcEngine.ts
@@ -75,7 +75,7 @@ export class JRPCEngine extends SafeEventEmitter {
       const end: JRPCEngineEndCallback = (err?: unknown) => {
         const error = err || res.error;
         if (error) {
-          if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available.";
+          if (Object.keys(error).includes("stack") === false) error.stack = "Stack trace is not available.";
 
           res.error = serializeError(error, {
             shouldIncludeStack: true,
@@ -321,7 +321,7 @@ export class JRPCEngine extends SafeEventEmitter {
       // Ensure no result is present on an errored response
       delete res.result;
       if (!res.error) {
-        if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available.";
+        if (Object.keys(error).includes("stack") === false) error.stack = "Stack trace is not available.";
 
         res.error = serializeError(error, {
           shouldIncludeStack: true,
@@ -415,7 +415,7 @@ export function providerFromEngine(engine: JRPCEngine): SafeEventEmitterProvider
   provider.sendAsync = async <T, U>(req: JRPCRequest<T>) => {
     const res = await engine.handle(req);
     if (res.error) {
-      if (globalThis.ReactNative) res.error.stack = "ReactNative flag is set. Stack trace is not available.";
+      if (Object.keys(res.error).includes("stack") === false) res.error.stack = "Stack trace is not available.";
 
       const err = serializeError(res.error, {
         fallbackError: {

--- a/packages/openlogin-jrpc/src/jrpcEngine.ts
+++ b/packages/openlogin-jrpc/src/jrpcEngine.ts
@@ -75,8 +75,8 @@ export class JRPCEngine extends SafeEventEmitter {
       const end: JRPCEngineEndCallback = (err?: unknown) => {
         const error = err || res.error;
         if (error) {
-          if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available."
-          
+          if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available.";
+
           res.error = serializeError(error, {
             shouldIncludeStack: true,
             fallbackError: {
@@ -321,7 +321,7 @@ export class JRPCEngine extends SafeEventEmitter {
       // Ensure no result is present on an errored response
       delete res.result;
       if (!res.error) {
-        if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available."
+        if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available.";
 
         res.error = serializeError(error, {
           shouldIncludeStack: true,
@@ -415,7 +415,7 @@ export function providerFromEngine(engine: JRPCEngine): SafeEventEmitterProvider
   provider.sendAsync = async <T, U>(req: JRPCRequest<T>) => {
     const res = await engine.handle(req);
     if (res.error) {
-      if (globalThis.ReactNative) res.error.stack = "ReactNative flag is set. Stack trace is not available."
+      if (globalThis.ReactNative) res.error.stack = "ReactNative flag is set. Stack trace is not available.";
 
       const err = serializeError(res.error, {
         fallbackError: {

--- a/packages/openlogin-jrpc/src/jrpcEngine.ts
+++ b/packages/openlogin-jrpc/src/jrpcEngine.ts
@@ -75,6 +75,8 @@ export class JRPCEngine extends SafeEventEmitter {
       const end: JRPCEngineEndCallback = (err?: unknown) => {
         const error = err || res.error;
         if (error) {
+          if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available."
+          
           res.error = serializeError(error, {
             shouldIncludeStack: true,
             fallbackError: {
@@ -319,6 +321,8 @@ export class JRPCEngine extends SafeEventEmitter {
       // Ensure no result is present on an errored response
       delete res.result;
       if (!res.error) {
+        if (globalThis.ReactNative) error.stack = "ReactNative flag is set. Stack trace is not available."
+
         res.error = serializeError(error, {
           shouldIncludeStack: true,
           fallbackError: {
@@ -411,6 +415,8 @@ export function providerFromEngine(engine: JRPCEngine): SafeEventEmitterProvider
   provider.sendAsync = async <T, U>(req: JRPCRequest<T>) => {
     const res = await engine.handle(req);
     if (res.error) {
+      if (globalThis.ReactNative) res.error.stack = "ReactNative flag is set. Stack trace is not available."
+
       const err = serializeError(res.error, {
         fallbackError: {
           message: res.error?.message || res.error?.toString(),


### PR DESCRIPTION
React Native crashed when try to access error.stack

workaround: overwrite error.stack when global.ReactNative is set