### PR TITLE
fix: bundle ESM color module in CJS build

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,6 +3,10 @@ import { readJSONFile } from "@toruslabs/torus-scripts/helpers/utils.js";
 import path from "path";
 
 const pkg = await readJSONFile(path.resolve("./package.json"));
+const allDeps = [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})];
+
+const forcedBundledDeps = ["color"];
+const deps = [...allDeps].filter((x) => !forcedBundledDeps.includes(x));
 
 export const baseConfig = {
   plugins: [
@@ -11,4 +15,5 @@ export const baseConfig = {
       preventAssignment: true,
     }),
   ],
+  external: [...deps, ...deps.map((x) => new RegExp(`^${x}/`)), /@babel\/runtime/],
 };


### PR DESCRIPTION
Related to this forum post: [forum post](https://web3auth.io/community/t/auth-core-color-esm-only-package-require-in-cjs-bundle/11170)