### PR TITLE
feat: parse `loginSource` to auth-service

### DIFF
--- a/examples/vue-example/package-lock.json
+++ b/examples/vue-example/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../..": {
       "name": "@web3auth/auth",
-      "version": "11.4.2",
+      "version": "11.4.3",
       "license": "MIT",
       "dependencies": {
         "@toruslabs/constants": "^16.1.1",
@@ -157,6 +157,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1553,6 +1554,7 @@
     "../../node_modules/@babel/runtime": {
       "version": "7.28.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2417,6 +2419,7 @@
       "version": "7.0.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3192,6 +3195,7 @@
       "version": "25.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3258,6 +3262,7 @@
       "version": "8.56.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -3617,6 +3622,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4081,6 +4087,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5084,6 +5091,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5142,6 +5150,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5254,6 +5263,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7619,6 +7629,7 @@
       "version": "0.5.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -8489,6 +8500,7 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8941,6 +8953,7 @@
       "version": "4.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9827,12 +9840,14 @@
     "../../node_modules/tslib": {
       "version": "2.8.1",
       "devOptional": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "../../node_modules/tsx": {
       "version": "4.21.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -9950,6 +9965,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10056,6 +10072,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -10167,6 +10184,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10240,6 +10258,7 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -10640,6 +10659,7 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -12638,6 +12658,7 @@
       "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.57.2",
@@ -12847,6 +12868,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -13898,6 +13920,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14217,6 +14240,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -14937,6 +14961,7 @@
       "version": "9.39.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15013,6 +15038,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -15139,6 +15165,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -15263,6 +15290,7 @@
       "version": "10.8.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -16591,6 +16619,7 @@
       "integrity": "sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^5.0.0",
@@ -17423,6 +17452,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17463,6 +17493,7 @@
       "version": "3.8.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -18263,7 +18294,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -18326,6 +18358,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18482,6 +18515,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18720,6 +18754,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -18868,6 +18903,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18957,6 +18993,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18969,6 +19006,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.31.tgz",
       "integrity": "sha512-iV/sU9SzOlmA/0tygSmjkEN6Jbs3nPoIPFhCMLD2STrjgOU8DX7ZtzMhg4ahVwf5Rp9KoFzcXeB1ZrVbLBp5/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.31",
         "@vue/compiler-sfc": "3.5.31",
@@ -18989,6 +19027,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -19274,6 +19313,7 @@
       "integrity": "sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
         "yaml": "^2.0.0"

--- a/examples/vue-example/package-lock.json
+++ b/examples/vue-example/package-lock.json
@@ -37,7 +37,7 @@
     },
     "../..": {
       "name": "@web3auth/auth",
-      "version": "11.4.3",
+      "version": "11.5.0",
       "license": "MIT",
       "dependencies": {
         "@toruslabs/constants": "^16.1.1",

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -348,7 +348,6 @@ export class Auth {
       },
       sessionId: this.sessionId,
       accessToken: await this.getAccessToken(),
-      refreshToken: await this.sessionManager.getRefreshToken(),
     };
 
     this.storeAuthPayload(loginId, dataObject, dataObject.options.sessionTime, true);

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -357,6 +357,7 @@ export class Auth {
       recordId,
       sessionNamespace: this.options.sessionNamespace,
       storageServerUrl: this.options.storageServerUrl,
+      loginSource: params.loginSource,
     };
 
     const loginUrl = constructURL({
@@ -539,6 +540,7 @@ export class Auth {
       recordId,
       sessionNamespace: this.options.sessionNamespace,
       storageServerUrl: this.options.storageServerUrl,
+      loginSource: dataObject.params.loginSource,
     };
 
     if (this.options.uxMode === UX_MODE.REDIRECT) {

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -348,6 +348,7 @@ export class Auth {
       },
       sessionId: this.sessionId,
       accessToken: await this.getAccessToken(),
+      refreshToken: await this.sessionManager.getRefreshToken(),
     };
 
     this.storeAuthPayload(loginId, dataObject, dataObject.options.sessionTime, true);

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -554,6 +554,11 @@ export interface BaseLoginParams {
    * Optional record id to be used for analytics purposes.
    */
   recordId?: string;
+
+  /**
+   * Optional login source to be used for analytics purposes.
+   */
+  loginSource?: string;
 }
 
 export interface AuthRequestPayload {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -562,6 +562,7 @@ export interface AuthRequestPayload {
   params: Partial<LoginParams>;
   sessionId?: string;
   accessToken?: string;
+  refreshToken?: string;
 }
 
 export interface AuthTokenResponse {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -567,7 +567,6 @@ export interface AuthRequestPayload {
   params: Partial<LoginParams>;
   sessionId?: string;
   accessToken?: string;
-  refreshToken?: string;
 }
 
 export interface AuthTokenResponse {


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->
This PR includes parsing `loginSource` to `auth-service`, so that we can correctly determine the `source` in the citadel login-record table. 

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auth redirect/popup URL construction by adding a new optional `loginSource` param, so any mismatch in parameter handling could impact login flows. Change is small and additive, primarily affecting analytics/auditing metadata.
> 
> **Overview**
> Propagates an optional `loginSource` value into the `b64Params` sent to the auth-service for both the standard auth flow (`authHandler`) and the MFA management flow (`manageMFA`), enabling downstream login-record attribution.
> 
> Updates the `BaseLoginParams` interface to include `loginSource`, and refreshes the Vue example `package-lock.json` (including bumping `@web3auth/auth` to `11.5.0` and lockfile metadata tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a296c03f9f5d6c4f122acd5d8fdb532aed59c6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->