### PR TITLE
fix: handle undefined MessageEvent in postMessageStream

### DIFF
--- a/src/jrpc/postMessageStream.ts
+++ b/src/jrpc/postMessageStream.ts
@@ -4,10 +4,13 @@ import { cloneDeep } from "../utils";
 import { BasePostMessageStream, isValidStreamMessage, type PostMessageEvent } from "./basePostMessageStream";
 
 /* istanbul ignore next */
-const getSource = Object.getOwnPropertyDescriptor(MessageEvent.prototype, "source")?.get;
+const messageEventPrototype = typeof MessageEvent === "undefined" ? undefined : MessageEvent.prototype;
 
 /* istanbul ignore next */
-const getOrigin = Object.getOwnPropertyDescriptor(MessageEvent.prototype, "origin")?.get;
+const getSource = messageEventPrototype ? Object.getOwnPropertyDescriptor(messageEventPrototype, "source")?.get : undefined;
+
+/* istanbul ignore next */
+const getOrigin = messageEventPrototype ? Object.getOwnPropertyDescriptor(messageEventPrototype, "origin")?.get : undefined;
 
 export interface PostMessageStreamArgs extends DuplexOptions {
   name: string;

--- a/test/postMessageStream.test.ts
+++ b/test/postMessageStream.test.ts
@@ -72,4 +72,12 @@ describe("PostMessageStream", () => {
     expect(message.target).toBe("auth");
     expect(message.data.data.params[0]._origin).toBe("https://current.example");
   });
+
+  it("can be imported when MessageEvent is undefined", async () => {
+    vi.unstubAllGlobals();
+    // Simulate Hermes/React Native where MessageEvent is absent.
+    Reflect.deleteProperty(globalThis, "MessageEvent");
+
+    await expect(import("../src/jrpc")).resolves.toHaveProperty("PostMessageStream");
+  });
 });


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->

- Guard MessageEvent.prototype access in PostMessageStream so importing @web3auth/auth does not throw in non-browser runtimes (e.g. Hermes/React Native) where MessageEvent is undefined.
- The package root re-exports PostMessageStream via the jrpc barrel, so this was an import-time failure even when consumers never instantiate the class.

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard at module init with unchanged browser behavior when MessageEvent is present; limited to JRPC postMessage stream setup.
> 
> **Overview**
> **Fixes a module-load crash** when `MessageEvent` is missing (e.g. Hermes/React Native). `postMessageStream` no longer reads `MessageEvent.prototype` at import time; it only resolves the `source`/`origin` property getters when `MessageEvent` exists, and the existing `_onMessageHandler` fallbacks to `event.origin` / `event.source` still apply when those getters are absent.
> 
> Adds a test that deletes global `MessageEvent` and asserts `import("../src/jrpc")` still exposes `PostMessageStream`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cf89be3fee1e653cd1f92cf9ef5ba1e1cac47a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->